### PR TITLE
User options

### DIFF
--- a/src/BenchmarkManager.py
+++ b/src/BenchmarkManager.py
@@ -299,7 +299,6 @@ class BenchmarkManager:
                 if not config[key_in_cond][0] in config_answer.get("if")["in"]:
                     continue
                     
-            values = None
             if len(config_answer['values']) == 1:
                 # When there is only 1 value to choose from skip the user input for now
                 values = config_answer['values']

--- a/src/BenchmarkManager.py
+++ b/src/BenchmarkManager.py
@@ -320,7 +320,7 @@ class BenchmarkManager:
                                        )])
                 values = answer[key]
             
-            if not config_answer.get("postproc") is None:
+            if config_answer.get("postproc"):
                 #the value of config_answer.get("postproc") is expected to be callable
                 #with each of the user selected values as argument.
                 #Note that the stored config file will contain the processed values.

--- a/src/BenchmarkManager.py
+++ b/src/BenchmarkManager.py
@@ -269,7 +269,7 @@ class BenchmarkManager:
     def _query_for_config(param_opts: dict, prefix: str = "") -> dict:
         config = {}
         for key, config_answer in param_opts.items():
-            if not config_answer.get("if") is None:
+            if config_answer.get("if"):
                 #
                 #support parameter descriptions like
                 #"seed": {


### PR DESCRIPTION
Hallo Philipp,

dieser request beeinhaltet Erweiterungen der Möglichkeiten die user-Abfrage zu steuern.

Neue Schlüsselwörter sind:

- exclusive 
- if
- postproc 


example:
        return {
            "graph_type": {
                "values": ["circular", "erdos-renyi"],
                "description": "What type of graph do you want?",
                "exclusive": True
            },
            "seed": {
                "if": {"key":"graph_type", "in" : ["erdos-renyi"]},
                "values": list([79117, "random", None]),
                "description": "The seed used for the graph creation. 'random' implies a randomly chosen seed.",
                "exclusive": True,
                "postproc": lambda s: np.random.randint(100000) if s == "random" else s
            },
            "nodes": {
                "values": list([3, 4, 6, 8, 10, 14, 16]),
                "description": "How many nodes does you graph need?"
            }
        }

Viele Grüße,
Jürgen