### PR TITLE
Rollback to Python 3.9.16

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.11.0
+  - python=3.9.16
   - numpy=1.24.1
   - pandas=1.5.3
   - seaborn=0.12.2


### PR DESCRIPTION
Since python 3.11.x is causing some problems for some users, we have to decided to rollback to the python 3.9.16 for now.