### PR TITLE
use better way to get username

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -18,15 +18,10 @@ import os
 import logging
 import datetime
 import os
+import getpass
 
 run_timestamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
-
-try:
-    username = os.getlogin()
-except Exception as e:
-    # TODO Handle this in a smarter way in case os.getlogin() fails
-    username = "unknownuser"
-
+username = getpass.getuser()
 bucket_name = 'amazon-braket-benchmark-framework-{}-{}'.format(run_timestamp, username)
 
 """


### PR DESCRIPTION
os.getlogin() doesn't work with Windows-Subsystem for Linux (WSL) and/or Docker. In a Docker container hosted on a Linux host, the file os.getlogin() tries to read the user from (/proc/self/loginuid) contains a value of '-1', i.e. no user is set. This throws the error:
"OSError: [Errno 6] No such device or address"
In WSL and a Docker container hosted from Windows with WSL, the file simply doesn't exist and os.getlogin() throws: "FileNotFoundError: [Errno 2] No such file or directory"

Fixes: 90bf9edc9e52 ("improving configuration")