### PR TITLE
Unify calls of pre and postprocess calls

### DIFF
--- a/src/BenchmarkManager.py
+++ b/src/BenchmarkManager.py
@@ -137,14 +137,15 @@ class BenchmarkManager:
                                                                          i, repetitions)
                         self.application.metrics.set_module_config(backlog_item["config"])
                         problem, preprocessing_time = self.application.preprocess(None, backlog_item["config"],
-                                                                                  store_dir=path)
+                                                                                  store_dir=path, rep_count=i)
                         self.application.metrics.set_preprocessing_time(preprocessing_time)
                         self.application.save(path, i)
 
                         processed_input, benchmark_record = self.traverse_config(backlog_item["submodule"], problem,
-                                                                                 path)
+                                                                                 path, rep_count=i)
 
-                        _, postprocessing_time = self.application.postprocess(processed_input, None, store_dir=path)
+                        _, postprocessing_time = self.application.postprocess(processed_input, None, store_dir=path,
+                                                                              rep_count=i)
                         self.application.metrics.set_postprocessing_time(postprocessing_time)
                         self.application.metrics.validate()
                         benchmark_record.append_module_record_left(deepcopy(self.application.metrics))
@@ -166,7 +167,7 @@ class BenchmarkManager:
         except KeyboardInterrupt:
             logging.warning("CTRL-C detected. Still trying to create results.json.")
 
-    def traverse_config(self, module: dict, input_data: any, path: str) -> (any, BenchmarkRecord):
+    def traverse_config(self, module: dict, input_data: any, path: str, rep_count: int) -> (any, BenchmarkRecord):
         """
         Executes a benchmark by traversing down the initialized config recursively until it reaches the end. Then
         traverses up again. Once it reaches the root/application, a benchmark run is finished.
@@ -177,6 +178,8 @@ class BenchmarkManager:
         :type input_data: any
         :param path: Path in case the modules want to store anything
         :type path: str
+        :param rep_count: The iteration count
+        :type rep_count: int
         :return: tuple with the output of this step and the according BenchmarkRecord
         :rtype: tuple(any, BenchmarkRecord)
         """
@@ -188,7 +191,8 @@ class BenchmarkManager:
         module_instance.metrics.set_module_config(module["config"])
         module_instance.preprocessed_input, preprocessing_time = module_instance.preprocess(input_data,
                                                                                             module["config"],
-                                                                                            store_dir=path)
+                                                                                            store_dir=path,
+                                                                                            rep_count=rep_count)
         module_instance.metrics.set_preprocessing_time(preprocessing_time)
 
         # Check if end of the chain is reached
@@ -196,14 +200,15 @@ class BenchmarkManager:
             # If we reach the end of the chain we create the benchmark record, fill it and then pass it up
             benchmark_record = self.benchmark_record_template.copy()
             module_instance.postprocessed_input, postprocessing_time = module_instance.postprocess(
-                module_instance.preprocessed_input, module["config"])
+                module_instance.preprocessed_input, module["config"], store_dir=path, rep_count=rep_count)
 
         else:
             processed_input, benchmark_record = self.traverse_config(module["submodule"],
-                                                                     module_instance.preprocessed_input, path)
+                                                                     module_instance.preprocessed_input, path, rep_count)
             module_instance.postprocessed_input, postprocessing_time = module_instance.postprocess(processed_input,
                                                                                                    module["config"],
-                                                                                                   store_dir=path)
+                                                                                                   store_dir=path,
+                                                                                                   rep_count=rep_count)
 
         output = module_instance.postprocessed_input
         module_instance.metrics.set_postprocessing_time(postprocessing_time)


### PR DESCRIPTION
The key word arguments added are needed to get some old (QUARK1) modules running.
We need this as prerequisite for our QUARK2 adapter.