### PR TITLE
fix numpy encoder

### DIFF
--- a/src/BenchmarkManager.py
+++ b/src/BenchmarkManager.py
@@ -351,4 +351,4 @@ class NumpyEncoder(json.JSONEncoder):
             return float(o)
         if isinstance(o, np.ndarray):
             return o.tolist()
-        return super(NumpyEncoder).default(o)
+        return super().default(o)


### PR DESCRIPTION
The NumpyEncoder in BenchmarkManager throws an exception if it runs into its default branch.  
This is fixed in this pull request.