### PR TITLE
Automatic creation of requirements_full.txt

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,4 +19,4 @@ sphinx:
 # https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
    install:
-    - requirements: docs/requirements.txt
+    - requirements: .settings/requirements_full.txt

--- a/.settings/requirements_full.txt
+++ b/.settings/requirements_full.txt
@@ -1,10 +1,12 @@
-sphinx==6.2.1
-sphinx-rtd-theme==1.2.0
 seaborn==0.12.2
-pandas==1.5.3
 networkx==2.8.8
 inquirer==3.1.2
+packaging==23.1
 pyyaml==6.0
+typing-extensions==4.6.3
+sphinx==6.2.1
+sphinx-rtd-theme==1.2.0
+numpy==1.23.5
 dimod==0.12.5
 amazon-braket-sdk==1.35.1
 scipy==1.10.1

--- a/src/Installer.py
+++ b/src/Installer.py
@@ -51,7 +51,9 @@ class Installer:
             {"name": "inquirer", "version": "3.1.2"},
             {"name": "packaging", "version": "23.1"},
             {"name": "pyyaml", "version": "6.0"},
-            {"name": "typing-extensions", "version": "4.6.3"}
+            {"name": "typing-extensions", "version": "4.6.3"},
+            {"name": "sphinx", "version": "6.2.1"},
+            {"name": "sphinx-rtd-theme", "version": "1.2.0"},
         ]
         Path(self.envs_dir).mkdir(parents=True, exist_ok=True)
 

--- a/src/Installer.py
+++ b/src/Installer.py
@@ -308,6 +308,9 @@ class Installer:
         with open(f"{self.settings_dir}/module_db.json", "w") as jsonFile:
             json.dump(module_db, jsonFile, indent=2)
 
+        requirements = self.collect_requirements(module_db_modules)
+        self.create_req_file(requirements, "full", self.settings_dir)
+
         logging.info("Created module_db file")
 
     @staticmethod
@@ -352,12 +355,12 @@ class Installer:
         else:
             return 0
 
-    def collect_requirements(self, env: dict) -> dict:
+    def collect_requirements(self, env: list[dict]) -> dict:
         """
         Collects requirements of the different modules in the given env file
 
         :param env: env file
-        :type env: dict
+        :type env: list[dict]
         :return: Collected requirements
         :rtype: dict
         """
@@ -406,7 +409,7 @@ class Installer:
 
         return requirements
 
-    def create_conda_file(self, requirements: dict, name: str) -> None:
+    def create_conda_file(self, requirements: dict, name: str, directory: str = None) -> None:
         """
         Creates conda yaml file based on the requirements
 
@@ -414,9 +417,13 @@ class Installer:
         :type requirements: dict
         :param name: Name of the conda env
         :type name: str
+        :param directory: Directory where the file should be saved. If None self.envs_dir will be taken
+        :type directory: str
         :return:
         :rtype: None
         """
+        if directory is None:
+            directory = self.envs_dir
         conda_data = {
             "name": name,
             "channels": ["defaults"],
@@ -427,13 +434,13 @@ class Installer:
 
             ]
         }
-        with open(f"{self.envs_dir}/conda_{name}.yml", "w") as filehandler:
+        with open(f"{directory}/conda_{name}.yml", "w") as filehandler:
             yaml.dump(conda_data, filehandler)
 
         logging.info("Saved conda env file, if you like to install it run:")
-        logging.info(f"conda env create -f {self.envs_dir}/conda_{name}.yml")
+        logging.info(f"conda env create -f {directory}/conda_{name}.yml")
 
-    def create_req_file(self, requirements: dict, name: str) -> None:
+    def create_req_file(self, requirements: dict, name: str, directory: str = None) -> None:
         """
         Creates pip txt file based on the requirements
 
@@ -441,16 +448,20 @@ class Installer:
         :type requirements: dict
         :param name: Name of the env
         :type name: str
+        :param directory: Directory where the file should be saved. If None self.envs_dir will be taken
+        :type directory: str
         :return:
         :rtype: None
         """
-        with open(f"{self.envs_dir}/requirements_{name}.txt", "w") as filehandler:
+        if directory is None:
+            directory = self.envs_dir
+        with open(f"{directory}/requirements_{name}.txt", "w") as filehandler:
             for k, v in requirements.items():
                 filehandler.write(f"{k}=={v[0]}" if v else k)
                 filehandler.write("\n")
 
         logging.info("Saved pip txt file, if you like to install it run:")
-        logging.info(f"pip install -r {self.envs_dir}/requirements_{name}.txt")
+        logging.info(f"pip install -r {directory}/requirements_{name}.txt")
 
     def list_envs(self) -> None:
         """


### PR DESCRIPTION
This PR adds the functionality to create the requirements_full.txt when creating the module database automatically. This file can then be used in the build of the read-the-docs documentation.

The successful build of the documentation can be seen here: https://quark-framework.readthedocs.io/en/automaticrequirementsfile/