### PR TITLE
fix exclusive mode in ConfigManager

### DIFF
--- a/src/ConfigManager.py
+++ b/src/ConfigManager.py
@@ -325,9 +325,11 @@ class ConfigManager:
                 print(f"{prefix} {config_answer['description']}: {config_answer['values'][0]}")
 
             elif config_answer.get('exclusive', False):
-                answer = checkbox(key=key,
-                                  message=f"{prefix} {config_answer['description']}",
-                                  choices=config_answer['values'])
+                answer = inquirer.prompt(
+                    [inquirer.List(key,
+                                   message=f"{prefix} {config_answer['description']}",
+                                   choices=config_answer['values']
+                                   )])
                 values = (answer[key],)
             else:
 


### PR DESCRIPTION
If a QUARK parameter is declared as exclusive multiple selections have been possible and the selected value was stored as a list. This gets fixed with this commit.

Note that the check that something is selected (provided by utils.checkbox) is not needed here because in the list mode of the inquirer always one entry is selected.