### PR TITLE
Fix bug in create_benchmark_backlog

### DIFF
--- a/src/ConfigManager.py
+++ b/src/ConfigManager.py
@@ -256,13 +256,13 @@ class ConfigManager:
                             }
                         })
             else:
-                return [{
+                items.append({
                     "name": module["name"],
                     "instance": module["instance"],
                     "config": single_config,
                     "submodule": {
                     }
-                }]
+                })
 
         return items
 


### PR DESCRIPTION
This PR fixes a bug where the benchmark backlog was not created in a correct manner for the last submodule in a chain in some situations.