### PR TITLE
Implement function that translates QUARK 1 config to QUARK 2 config f…

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -177,7 +177,7 @@ def handle_benchmark_run(args: argparse.Namespace) -> None:
                 try:
                     benchmark_config = yaml.load(filehandler, Loader=yaml.FullLoader)
                 except Exception as e:
-                    logging.error(f"ERROR: Problem loading the given config file: {e}")
+                    logging.exception("Problem loading the given config file")
                     raise ValueError("Config file needs to be a valid QUARK YAML Config!") from e
 
                 config_manager.set_config(benchmark_config)


### PR DESCRIPTION
This PR adds the feature to automatically translate legacy configs from QUARK 1 to a QUARK 2 configs as requested by @jusschwitalla  .

For legacy configs with a "Direct" mapping we assume that this "Direct" mapping is not existing anymore in QUARK 2.0 (for example for TSP GreedySolver.

Example QUARK 1 config:

```

application:
  config:
    nodes:
    - 3
  name: TSP
mapping:
  Direct:
    config: {}
    solver:
    - config: {}
      device:
      - config: {}
        name: Local
      name: GreedyClassicalTSP
  Ising:
    config:
      lagrange_factor:
      - 0.75
      mapping:
      - ocean
    solver:
    - config:
        coeff_scale:
        - 0.01
        iterations:
        - 1
        layers:
        - 1
        shots:
        - 10
        stepsize:
        - 0.0001
      device:
      - config: {}
        name: default.qubit
      name: PennylaneQAOA
  QUBO:
    config:
      lagrange_factor:
      - 0.75
    solver:
    - config:
        number_of_reads:
        - 100
      device:
      - config: {}
        name: Simulated Annealer
      name: Annealer
repetitions: 1

```