### PR TITLE
Move away from soon deprecated functions read_gpickle and write_gpickle

### DIFF
--- a/src/modules/applications/optimization/PVC/PVC.py
+++ b/src/modules/applications/optimization/PVC/PVC.py
@@ -14,6 +14,7 @@
 
 import itertools
 from typing import TypedDict
+import pickle
 
 import networkx as nx
 import numpy as np
@@ -137,7 +138,8 @@ class PVC(Optimization):
         seams = config['seams']
 
         # Read in the original graph
-        graph = nx.read_gpickle(os.path.join(os.path.dirname(__file__), "data", "reference_graph.gpickle"))
+        with open(os.path.join(os.path.dirname(__file__), "data", "reference_graph.gpickle"), "rb") as file:
+            graph = pickle.load(file)
 
         # Remove seams until the target number of seams is reached
         # Get number of seam in graph
@@ -300,4 +302,5 @@ class PVC(Optimization):
         return distance, end_time_measurement(start)
 
     def save(self, path: str, iter_count: int) -> None:
-        nx.write_gpickle(self.application, f"{path}/graph_iter_{iter_count}.gpickle")
+        with open(f"{path}/graph_iter_{iter_count}.gpickle", "wb") as file:
+            pickle.dump(self.application, file, pickle.HIGHEST_PROTOCOL)

--- a/src/modules/applications/optimization/PVC/data/createReferenceGraph.py
+++ b/src/modules/applications/optimization/PVC/data/createReferenceGraph.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 
 import networkx as nx
+import pickle
 
 # Read in the original graph
 graph = nx.MultiDiGraph()
@@ -58,4 +59,5 @@ with open("reference_data.txt") as infile:
             graph.add_edge((s_start, n_start), (s_end, n_end), c_start=c_start, t_start=t_start, c_end=c_end,
                            t_end=t_end, weight=duration)
 
-nx.write_gpickle(graph, "reference_graph.gpickle")
+with open("reference_graph.gpickle", "wb") as file:
+    pickle.dump(graph, file, pickle.HIGHEST_PROTOCOL)

--- a/src/modules/applications/optimization/TSP/TSP.py
+++ b/src/modules/applications/optimization/TSP/TSP.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 
 from typing import TypedDict
+import pickle
 
 import networkx as nx
 import numpy as np
@@ -153,7 +154,8 @@ class TSP(Optimization):
         nodes = config['nodes']
 
         # Read in the original graph
-        graph = nx.read_gpickle(os.path.join(os.path.dirname(__file__), "data", "reference_graph.gpickle"))
+        with open(os.path.join(os.path.dirname(__file__), "data", "reference_graph.gpickle"), "rb") as file:
+            graph = pickle.load(file)
 
         # Remove seams until the target number of seams is reached
         # Get number of seam in graph
@@ -293,4 +295,5 @@ class TSP(Optimization):
         return distance_with_return, end_time_measurement(start)
 
     def save(self, path: str, iter_count: int) -> None:
-        nx.write_gpickle(self.application, f"{path}/graph_iter_{iter_count}.gpickle")
+        with open(f"{path}/graph_iter_{iter_count}.gpickle", "wb") as file:
+            pickle.dump(self.application, file, pickle.HIGHEST_PROTOCOL)

--- a/src/modules/applications/optimization/TSP/data/createReferenceGraph.py
+++ b/src/modules/applications/optimization/TSP/data/createReferenceGraph.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 
 import networkx as nx
+import pickle
 import tsplib95
 
 # Source http://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/tsp/
@@ -29,6 +30,7 @@ for edge in graph.edges:
 print("Loaded graph:")
 print(nx.info(graph))
 
-nx.write_gpickle(graph, "reference_graph.gpickle")
+with open("reference_graph.gpickle", "wb") as file:
+    pickle.dump(graph, file, pickle.HIGHEST_PROTOCOL)
 
 print("Saved graph as reference_graph.gpickle")


### PR DESCRIPTION
As `read_gpickle` and `write_gpickle` will be depcreated soon, we move to the native pickle functions as described in the migration guide: https://networkx.org/documentation/stable/release/migration_guide_from_2.x_to_3.0.html#deprecated-code