### PR TITLE
Minor sphinx confic adjustment

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -106,6 +106,9 @@ html_static_path = []
 #
 # html_sidebars = {}
 
+# If smartquotes is True, double dashes (--) are transformed to en-dashes (–)
+# which could be confused with single dashes (-).
+smartquotes = False
 
 # -- Options for HTMLHelp output ---------------------------------------------
 


### PR DESCRIPTION
Set smartquotes to False to avoid double dashes being converted to en-dashes in the readthedocs.