### PR TITLE
Move import of Plotter to the correct location.

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -21,7 +21,6 @@ from collections.abc import Iterable
 import yaml
 
 from Installer import Installer
-from Plotter import Plotter
 from utils import _expand_paths
 from utils_mpi import MPIStreamHandler, MPIFileHandler, get_comm
 
@@ -157,6 +156,8 @@ def handle_benchmark_run(args: argparse.Namespace) -> None:
     :rtype: None
     """
     from BenchmarkManager import BenchmarkManager  # pylint: disable=C0415
+    from Plotter import Plotter  # pylint: disable=C0415
+
     benchmark_manager = BenchmarkManager(fail_fast=args.failfast)
 
     if args.summarize:


### PR DESCRIPTION
Move import of Plotter to a later point to remove the need to install the dependencies of the Plotter class when installing a QUARK env for the first time.