### PR TITLE
Debug RandomClassicPVC

### DIFF
--- a/src/modules/solvers/RandomClassicalPVC.py
+++ b/src/modules/solvers/RandomClassicalPVC.py
@@ -102,7 +102,8 @@ class RandomPVC(Solver):
         while len(mapped_problem.nodes) > 2:
             # Get the random neighbor edge from the current node
             next_node = random.choice([x for x in mapped_problem.edges(current_node[0], data=True) if
-                                       x[2]['c_start'] == current_node[1] and x[2]['t_start'] == current_node[2]])
+                                       x[1][0] != current_node[0][0] and x[2]['c_start'] == current_node[1]
+                                       and x[2]['t_start'] == current_node[2]])
             next_node = (next_node[1], next_node[2]["c_end"], next_node[2]["t_end"])
 
             # Make the step - add distance to cost, add the best node to tour,


### PR DESCRIPTION
Random choice could have been the same seam before this fix, which leads to a removal of the current seam/node combination in line 113 and subsequently to an empty list of edges to choose from for the random choice in the next iteration of the for loop.