### PR TITLE
Bugfix Docker

### DIFF
--- a/.github/workflows/container_build_publish.yml
+++ b/.github/workflows/container_build_publish.yml
@@ -4,7 +4,7 @@ name: Create and publish a QUARK Docker image
 # Configures this workflow to run every time a change is pushed to the branch called `main` or `dev`.
 on:
   push:
-    branches: ['main', 'dev']
+    branches: ['main', 'dev', 'dev_docker_bugfix']
   release:
     types: [ published ]
 

--- a/.github/workflows/container_build_publish.yml
+++ b/.github/workflows/container_build_publish.yml
@@ -4,7 +4,7 @@ name: Create and publish a QUARK Docker image
 # Configures this workflow to run every time a change is pushed to the branch called `main` or `dev`.
 on:
   push:
-    branches: ['main', 'dev', 'dev_docker_bugfix']
+    branches: ['main', 'dev']
   release:
     types: [ published ]
 

--- a/.github/workflows/container_build_publish.yml
+++ b/.github/workflows/container_build_publish.yml
@@ -24,6 +24,17 @@ jobs:
       packages: write
       #
     steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          # Set to "false" if necessary for your workflow
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: false
+          swap-storage: true
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Set up QEMU


### PR DESCRIPTION
Because of the most recently added packages, building the docker image took too much time (resulting in "read timeout error") and space (resulting in "running out of memory error"). Adjusted default timeout in Dockerfile and added a clean-up step in the GitHub workflow that is responsible for building the Docker image